### PR TITLE
Log attachments on deletion

### DIFF
--- a/plugins/logging.py
+++ b/plugins/logging.py
@@ -99,8 +99,15 @@ class LoggingCog(commands.Cog):
             embed = discord.Embed(
                 color=discord.Color.red(),
             )
+            
+            files = []
+            for attachment in message.attachments:
+                files.append(await attachment.to_file())
 
             embed.set_thumbnail(url=message.author.avatar.url if message.author.avatar else None)
             embed.add_field(name="", value=f"{message.author.mention} deleted a message in {message.channel.mention}", inline=False)
             embed.add_field(name="", value=f"{message.content[:2000] or '*[No content]*'}", inline=False)
-            await channel.send(embed=embed, silent=True)
+            if files:
+                await channel.send(embed=embed, files=files, silent=True)
+            else:
+                await channel.send(embed=embed, silent=True)


### PR DESCRIPTION
The main downside of this implementation is that the attachments appear ***above*** the embed.
I would've done it on edits as well, but it will become way too much clutter with attachments