### PR TITLE
feat: implement verification similar to bans

### DIFF
--- a/plugins/verification.py
+++ b/plugins/verification.py
@@ -36,6 +36,7 @@ class VerificationCog(commands.Cog):
 
         if time is None:
             await ctx.send(f"{await author_ping(ctx)} Please provide a time. ``!verificationtime <time>``" )
+            return
 
         # Time is an int, interpret as seconds
         if time.isdigit():


### PR DESCRIPTION
On joins, the user id, server id along with time to be verified is added to the db. a task runs and adds accordingly before removing entries it verified. Sorry for the inconvenience